### PR TITLE
chore(ignore-files): ignore webstorm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .config
 .DS_Store
 .git
+.idea
 .local
 /.sass-cache
 /connect.lock


### PR DESCRIPTION
Ignore the `.idea` folder that the WebStorm IDE generates