### PR TITLE
fix(account): qr code nano prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ jsconfig.json
 npm-debug.log*
 testem.log
 yarn-error.log
+.idea
 
 # ember-try
 .node_modules.ember-try/

--- a/app/components/account-card/template.hbs
+++ b/app/components/account-card/template.hbs
@@ -6,7 +6,7 @@
           {{bs-tooltip fade=true delayShow=500 placement='top' title=(t 'editAccountSettings')}}
           {{fa-icon 'cog' size='2' ariaLabel=(t 'editAccountSettings')}}
         {{/link-to}}
-        {{qr-code text=account.id width=170 height=170}}
+        {{qr-code text=(to-nano-prefix account.id) width=170 height=170}}
       {{/if}}
       <p class="balance">
         <sup>


### PR DESCRIPTION
Make QR code show nano_ prefix instead of xrb_
Add Webstorm's .idea to gitignore.